### PR TITLE
Use docker/metadata-action to generate tags and labels to prepare releaseing images on a git tag with semver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
-name: Build and Test
+name: Build, Test & push
 
 on:
   push:
-    branches:
-    - "dev*"  # Support wildcard matching
-
   pull_request:
-    branches: [ dev ]
+  release:
+    types: # This configuration does not affect the page_build event above
+      - published
+      - released
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -21,39 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@3.6.0
 
-      - name: Get git vars
-        shell: bash
-        run: |
-          echo "::set-output name=BRANCH::$(echo "${{ env.GITHUB_REF_SLUG }}")"
-          echo "::set-output name=IMAGE_VERSION::$( git describe --tags --dirty --match "v[0-9]*")"
-        id: gitVars
-
-      - name: prepare some vars
-        id: buildVars
-        run: |
-          VARIANT_IMAGE="${{ steps.gitVars.outputs.IMAGE_VERSION }}-${{ steps.gitVars.outputs.BRANCH }}"
-          echo "::set-output name=VARIANT::$(echo "${VARIANT_IMAGE}")"
-          echo "::set-output name=VARIANT_IMAGE::$(echo "$VARIANT_IMAGE")"
-          echo "::set-output name=BUILD_DATE::$(  date --iso-8601=seconds --utc )"
-          # detect rolling branch
-          if [[ ${{ steps.gitVars.outputs.BRANCH }} == "master" ]]; then
-          echo "::set-output name=TAG_ROLLING::latest"
-          else
-          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" | tr '[A-Z]' '[a-z]' )"
-          fi
-
-      - name: Check variables
-        run: |
-          echo BRANCH: ${{ steps.gitVars.outputs.BRANCH }}
-          echo IMAGE_VERSION: ${{ steps.gitVars.outputs.IMAGE_VERSION }}
-          echo VARIANT: ${{ steps.buildVars.outputs.VARIANT }}
-          echo VARIANT_IMAGE: ${{ steps.buildVars.outputs.VARIANT_IMAGE }}
-          echo BUILD_DATE: ${{ steps.buildVars.outputs.BUILD_DATE }}
-          echo ROLLING_TAG: ${{ steps.buildVars.outputs.TAG_ROLLING }}
-          
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v1.2.0
         with:
@@ -67,9 +35,23 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-build-${{ github.sha }}
           restore-keys: |
+             ${{ runner.os }}-build-
              ${{ runner.os }}-buildx-
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: fhem/alexa-fhem
+          flavor: |
+             latest= ${{ fromJSON('["auto", "false"]')[github.event.release.prerelease == 1] }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}},enable=${{ github.event.release.prerelease == 0 }}
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Build for test full blown amd64 
         uses: docker/build-push-action@v2
@@ -82,19 +64,21 @@ jobs:
           push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
-          tags: fhem/alexa-fhem:${{ steps.buildVars.outputs.VARIANT }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BUILD_DATE=${{ steps.buildVars.outputs.BUILD_DATE }}
-            TAG=${{ steps.buildVars.outputs.VARIANT }}
-            TAG_ROLLING=${{ steps.buildVars.outputs.TAG_ROLLING }}
-            IMAGE_VERSION=${{ steps.buildVars.outputs.VARIANT }}
-            IMAGE_VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            IMAGE_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            IMAGE_VCS_REF=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             ALEXAFHEM_VERSION=0.5.61
+            L_USAGE=${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/README.md
+            L_VCS_URL=${{ github.server_url }}/${{ github.repository }}/
+            L_AUTHORS=${{ github.server_url }}/${{ github.repository }}/graphs/contributors
 
       - name: Inspect and run integration tests
         run: |
-          docker image inspect fhem/alexa-fhem:${{ steps.buildVars.outputs.VARIANT }}
-          docker history fhem/alexa-fhem:${{ steps.buildVars.outputs.VARIANT }}
+          docker image inspect ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          docker history ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           ./scripts/test-integration.sh;
 
   published_build:
@@ -108,41 +92,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@3.6.0
-
-      - name: Get git vars
-        shell: bash
-        run: |
-          echo "::set-output name=IMAGE_VERSION::$( git describe --tags --dirty --match "v[0-9]*")"
-          echo "::set-output name=BRANCH::$(echo "${{ env.GITHUB_REF_SLUG }}")"
-
-        id: gitVars
-
-
-      - name: prepare some vars
-        id: buildVars
-        run: |
-          VARIANT_IMAGE="${{ steps.gitVars.outputs.IMAGE_VERSION }}-${{ steps.gitVars.outputs.BRANCH }}"
-          echo "::set-output name=VARIANT::$(echo "${VARIANT_IMAGE}")"
-          echo "::set-output name=VARIANT_IMAGE::$(echo "$VARIANT_IMAGE")"
-          echo "::set-output name=BUILD_DATE::$(  date --iso-8601=seconds --utc )"
-          # detect rolling branch
-          if [[ ${{ steps.gitVars.outputs.BRANCH }} == "master" ]]; then
-          echo "::set-output name=TAG_ROLLING::latest"
-          else
-          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" | tr '[A-Z]' '[a-z]' )"
-          fi
-
-      - name: Check variables
-        run: |
-          echo BRANCH: ${{ steps.gitVars.outputs.BRANCH }}
-          echo IMAGE_VERSION: ${{ steps.gitVars.outputs.IMAGE_VERSION }}
-          echo VARIANT: ${{ steps.buildVars.outputs.VARIANT }}
-          echo VARIANT_IMAGE: ${{ steps.buildVars.outputs.VARIANT_IMAGE }}
-          echo BUILD_DATE: ${{ steps.buildVars.outputs.BUILD_DATE }}
-          echo ROLLING_TAG: ${{ steps.buildVars.outputs.TAG_ROLLING }}
-          
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v1.2.0
         with:
@@ -159,14 +108,29 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
            ${{ runner.os }}-buildx-
+           ${{ runner.os }}-build-
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/fhem/alexa-fhem
+          flavor: |
+             latest= ${{ fromJSON('["auto", "false"]')[github.event.release.prerelease == 1] }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}},enable=${{ github.event.release.prerelease == 0 }}
+            type=ref,event=branch
+            type=ref,event=pr
+            
       - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+          
       - name: Build and push cross compiled full blown image on supported platforms
         uses: docker/build-push-action@v2
         with:
@@ -174,16 +138,16 @@ jobs:
           load: false  
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'release' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/fhem/alexa-fhem:${{ steps.buildVars.outputs.TAG_ROLLING }}
-
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BUILD_DATE=${{ steps.buildVars.outputs.BUILD_DATE }}
-            TAG=${{ steps.buildVars.outputs.VARIANT }}
-            TAG_ROLLING=${{ steps.buildVars.outputs.TAG_ROLLING }}
-            IMAGE_VERSION=${{ steps.buildVars.outputs.VARIANT }}
-            IMAGE_VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            IMAGE_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            IMAGE_VCS_REF=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             ALEXAFHEM_VERSION=0.5.61
+            L_USAGE=${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/README.md
+            L_VCS_URL=${{ github.server_url }}/${{ github.repository }}/
+            L_AUTHORS=${{ github.server_url }}/${{ github.repository }}/graphs/contributors

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # Install base environment
-COPY ./src/qemu-* /usr/bin/
 COPY src/entry.sh /entry.sh
 COPY src/ssh_known_hosts.txt /ssh_known_hosts.txt
 COPY src/health-check.sh /health-check.sh
@@ -44,7 +43,7 @@ RUN  sed -i "s/stretch main/stretch main contrib non-free/g" /etc/apt/sources.li
     && apt-get autoremove -qqy && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.[^.] ~/.??* ~/*
 
-ARG ALEXAFHEM_VERSION="0.5.62"
+ARG ALEXAFHEM_VERSION="0.5.61"
 
 # Add nodejs app layer
 RUN LC_ALL=C curl --retry 3 --retry-connrefused --retry-delay 2 -fsSL https://deb.nodesource.com/setup_14.x | LC_ALL=C bash - \
@@ -61,7 +60,7 @@ RUN LC_ALL=C curl --retry 3 --retry-connrefused --retry-delay 2 -fsSL https://de
           alexa-fhem@${ALEXAFHEM_VERSION} \
       ; fi \
     && LC_ALL=C apt-get autoremove -qqy && LC_ALL=C apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.[^.] ~/.??* ~/* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.[^.] ~/.??* ~/* 
 
 # Add alexa-fhem app layer
 COPY src/config.json /alexa-fhem.src/alexa-fhem-docker.config.json
@@ -111,11 +110,11 @@ LABEL org.fhem.alexa.url=${L_URL_ALEXAFHEM}
 LABEL org.fhem.alexa.documentation=${L_USAGE_ALEXAFHEM}
 LABEL org.fhem.alexa.source=${L_VCS_URL_ALEXAFHEM}
 LABEL org.fhem.alexa.version=${ALEXAFHEM_VERSION}
-LABEL org.fhem.alexa.vendor=${L_VENDOR_ALEXAFHEM}
+LABEL org.fhem.alexa.vendor=${L_VENDOR_ALEXAFHEM}-${TARGETPLATFORM}
 LABEL org.fhem.alexa.licenses=${L_LICENSES_ALEXAFHEM}
 LABEL org.fhem.alexa.description=${L_DESCR_ALEXAFHEM}
 
-RUN echo "org.opencontainers.image.created=${BUILD_DATE}\norg.opencontainers.image.authors=${L_AUTHORS}\norg.opencontainers.image.url=${L_URL}\norg.opencontainers.image.documentation=${L_USAGE}\norg.opencontainers.image.source=${L_VCS_URL}\norg.opencontainers.image.version=${IMAGE_VERSION}\norg.opencontainers.image.revision=${IMAGE_VCS_REF}\norg.opencontainers.image.vendor=${L_VENDOR}\norg.opencontainers.image.licenses=${L_LICENSES}\norg.opencontainers.image.title=${L_TITLE}\norg.opencontainers.image.description=${L_DESCR}\norg.fhem.alexa.authors=${L_AUTHORS_ALEXAFHEM}\norg.fhem.alexa.url=${L_URL_ALEXAFHEM}\norg.fhem.alexa.documentation=${L_USAGE_ALEXAFHEM}\norg.fhem.alexa.source=${L_VCS_URL_ALEXAFHEM}\norg.fhem.alexa.version=${ALEXAFHEM_VERSION}\norg.fhem.alexa.revision=${VCS_REF}\norg.fhem.alexa.vendor=${L_VENDOR_ALEXAFHEM}\norg.fhem.alexa.licenses=${L_LICENSES_ALEXAFHEM}\norg.fhem.alexa.description=${L_DESCR_ALEXAFHEM}" > /image_info
+RUN echo "org.opencontainers.image.created=${BUILD_DATE}\norg.opencontainers.image.authors=${L_AUTHORS}\norg.opencontainers.image.url=${L_URL}\norg.opencontainers.image.documentation=${L_USAGE}\norg.opencontainers.image.source=${L_VCS_URL}\norg.opencontainers.image.version=${IMAGE_VERSION}\norg.opencontainers.image.revision=${IMAGE_VCS_REF}\norg.opencontainers.image.vendor=${L_VENDOR}-${TARGETPLATFORM}\norg.opencontainers.image.licenses=${L_LICENSES}\norg.opencontainers.image.title=${L_TITLE}\norg.opencontainers.image.description=${L_DESCR}\norg.fhem.alexa.authors=${L_AUTHORS_ALEXAFHEM}\norg.fhem.alexa.url=${L_URL_ALEXAFHEM}\norg.fhem.alexa.documentation=${L_USAGE_ALEXAFHEM}\norg.fhem.alexa.source=${L_VCS_URL_ALEXAFHEM}\norg.fhem.alexa.version=${ALEXAFHEM_VERSION}\norg.fhem.alexa.revision=${VCS_REF}\norg.fhem.alexa.vendor=${L_VENDOR_ALEXAFHEM}\norg.fhem.alexa.licenses=${L_LICENSES_ALEXAFHEM}\norg.fhem.alexa.description=${L_DESCR_ALEXAFHEM}" > /image_info
 
 
 VOLUME [ "/alexa-fhem" ]


### PR DESCRIPTION
Use docker/metadata-action to generate tags and labels to prepare releaseing images on a git tag with semver

* Image will be published if a release event occures
* Name of Tags will be taken from git tags if possible
* The tag latestwill only be applied if a release is not marked as prereelase!
* push and pull requests are not pushed to ghcr
* images will be tagged with their versions
* small improvements regarding caching
* corrected latest available alexa_fhem npm package
* improved some labels
* cleaned up the workflow
